### PR TITLE
feat: add plant scanning and help tooltips to AddPlantScreen

### DIFF
--- a/client/src/components/addPlant/HelpTooltip.js
+++ b/client/src/components/addPlant/HelpTooltip.js
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import {
+    View,
+    Text,
+    TouchableOpacity,
+    Modal,
+    StyleSheet,
+} from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+const HelpTooltip = ({ title, description, style }) => {
+    const [showTooltip, setShowTooltip] = useState(false);
+
+    return (
+        <>
+            <TouchableOpacity
+                style={[styles.helpButton, style]}
+                onPress={() => setShowTooltip(true)}
+            >
+                <Feather name="help-circle" size={16} color="#4CAF50" />
+            </TouchableOpacity>
+
+            <Modal
+                visible={showTooltip}
+                transparent={true}
+                animationType="fade"
+                onRequestClose={() => setShowTooltip(false)}
+            >
+                <TouchableOpacity
+                    style={styles.modalOverlay}
+                    activeOpacity={1}
+                    onPress={() => setShowTooltip(false)}
+                >
+                    <View style={styles.tooltipContainer}>
+                        <View style={styles.tooltipHeader}>
+                            <Text style={styles.tooltipTitle}>{title}</Text>
+                            <TouchableOpacity
+                                onPress={() => setShowTooltip(false)}
+                                style={styles.closeButton}
+                            >
+                                <Feather name="x" size={20} color="#6B7280" />
+                            </TouchableOpacity>
+                        </View>
+                        <Text style={styles.tooltipDescription}>{description}</Text>
+                    </View>
+                </TouchableOpacity>
+            </Modal>
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    helpButton: {
+        marginLeft: 8,
+        padding: 4,
+    },
+    modalOverlay: {
+        flex: 1,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: 20,
+    },
+    tooltipContainer: {
+        backgroundColor: '#FFFFFF',
+        borderRadius: 12,
+        padding: 20,
+        maxWidth: 300,
+        shadowColor: '#000',
+        shadowOffset: {
+            width: 0,
+            height: 2,
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 3.84,
+        elevation: 5,
+    },
+    tooltipHeader: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 12,
+    },
+    tooltipTitle: {
+        fontSize: 16,
+        fontWeight: '600',
+        color: '#1F2937',
+        flex: 1,
+    },
+    closeButton: {
+        padding: 4,
+    },
+    tooltipDescription: {
+        fontSize: 14,
+        color: '#6B7280',
+        lineHeight: 20,
+    },
+});
+
+export default HelpTooltip;

--- a/client/src/components/addPlant/styles.js
+++ b/client/src/components/addPlant/styles.js
@@ -67,6 +67,12 @@ const styles = StyleSheet.create({
     gap: 8,
     marginBottom: 8,
   },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
   label: {
     fontSize: 16,
     fontWeight: '500',
@@ -347,6 +353,33 @@ const styles = StyleSheet.create({
     color: '#4CAF50',
     fontFamily: 'Nunito_500Medium',
   },
-}); 
+
+  // Scan Button Styles
+  scanButtonContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  inputWithScan: {
+    flex: 1,
+  },
+  scanButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F0F9F0',
+    borderWidth: 1,
+    borderColor: '#4CAF50',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 8,
+  },
+  scanButtonText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#4CAF50',
+    fontFamily: 'Nunito_500Medium',
+  },
+});
 
 export default styles; 

--- a/client/src/components/main/styles.js
+++ b/client/src/components/main/styles.js
@@ -356,6 +356,54 @@ const styles = StyleSheet.create({
   gardenSettingsButton: {
     padding: 4,
   },
+
+  // Modal Styles
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    backgroundColor: '#FFFFFF',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    padding: 24,
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#2C3E50',
+    textAlign: 'center',
+    marginBottom: 24,
+    fontFamily: 'Nunito_700Bold',
+  },
+  modalButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    backgroundColor: '#F8F9FA',
+    borderRadius: 12,
+    marginBottom: 12,
+    gap: 12,
+  },
+  modalButtonText: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: '#2C3E50',
+    fontFamily: 'Nunito_500Medium',
+  },
+  cancelButton: {
+    backgroundColor: '#FEF2F2',
+    marginTop: 8,
+  },
+  cancelButtonText: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: '#E74C3C',
+    textAlign: 'center',
+    fontFamily: 'Nunito_500Medium',
+  },
 });
 
 export default styles; 

--- a/client/src/services/websocketService.js
+++ b/client/src/services/websocketService.js
@@ -9,8 +9,8 @@ const BACKEND_URL = Constants.expoConfig.extra.BACKEND_URL;
 const CONFIG = {
   // For local development, use 'localhost'
   // For network access, use your computer's IP address
-  SERVER_URL: 'ws://192.168.68.61:8080',
-  
+  SERVER_URL: 'ws://192.168.68.104:8080',
+
   // Alternative configurations
   // LOCAL: 'ws://localhost:8080'
   // NETWORK: 'ws://192.168.68.61:8080'


### PR DESCRIPTION
- Add scan button next to Plant Type field that navigates to plant identification
- Add help tooltips for Humidity, Water Limit, and Dripper Type fields
- Auto-fill plant type when returning from successful plant identification
- Update navigation flow to support scanning from AddPlantScreen
